### PR TITLE
Bump required version of Crisper

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "components"
   ],
   "dependencies": {
-    "crisper": "^1.0.3",
+    "crisper": "^1.2.0",
     "gulp-util": "^3.0.6",
     "object-assign": "^4.0.1",
     "through2": "^2.0.0"


### PR DESCRIPTION
Installing the latest version of gulp-crisper resulted in build errors for us that seemed to indicate it was Crisper itself causing the issues. It looks as though as requiring in the latest version of Crisper resolves that. 
- [x] Require `^1.2.0` of crisper
- [x] All tests pass
