### PR TITLE
Update crisper to 2.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "components"
   ],
   "dependencies": {
-    "crisper": "^2.0.0",
+    "crisper": "^2.0.1",
     "gulp-util": "^3.0.7",
     "object-assign": "^4.0.1",
     "through2": "^2.0.0"


### PR DESCRIPTION
Added support for finding scripts with type text/ecmascript-6
Useful for some IDE to recognize es2015 when inlined
See thie jetbrain issue : https://youtrack.jetbrains.com/issue/WEB-16444
