### PR TITLE
Generate the output js file at the specified path, if a jsFileName is specified in options.

### DIFF
--- a/index.js
+++ b/index.js
@@ -43,7 +43,11 @@ module.exports = function (opts) {
 
     Object.keys(split).forEach(function(type) {
       if (split[type]) {
-        stream.push(splitFile(file, splitfile[type], split[type]));
+        if (type === 'js' && opts && opts.jsFileName) {
+          stream.push(splitFile(file, opts.jsFileName, split[type]));  
+        } else {
+          stream.push(splitFile(file, splitfile[type], split[type]));
+        }
       }
     });
 

--- a/test.js
+++ b/test.js
@@ -55,6 +55,10 @@ describe('should do for csp', function () {
 			} else {
 				assert(null);
 			}
+
+			if (/\.js$/.test(file.path)) {
+				assert(/^tmp\/vulcanize.js$/.test(file.path));
+			}
 		});
 
 		stream.on('end', cb);
@@ -129,6 +133,9 @@ describe('should do for csp', function () {
 
 			if (/\.html$/.test(file.path)) {
 				assert(/script\/new-script.js/.test(contents));
+			}
+			if (/\.js$/.test(file.path)) {
+				assert(/^tmp\/script\/new-script.js$/.test(file.path));
 			}
 		});
 


### PR DESCRIPTION
Currently, with a jsFileName specified in options to crisper, the correct relative path is inserted in the crisp'd html file but the the js file is still generated at the default path. e.g

``` js
 return gulp.src('app/index.html')
  .pipe(vulcanize({
    inlineScripts: true,
    inlineCss: true,
    stripComments: true
  }))
  .pipe(polyclean.uglifyJs())
  .pipe(crisper({
    jsFileName: "static/js/index.js"
  }))
  .pipe(gulp.dest('dist'));
```

creates

``` sh
$ ls -R dist
index.html index.js
```

This patch makes it such that the generated js file is written to the path as specified in jsFileName. e.g.

``` sh
$ ls -R dist
index.html static

dist/static:
js

dist/static/js:
index.js
```
