### PR TITLE
Write out an empty script if that is requested

### DIFF
--- a/index.js
+++ b/index.js
@@ -42,7 +42,7 @@ module.exports = function (opts) {
     var stream = this;
 
     Object.keys(split).forEach(function(type) {
-      if (split[type]) {
+      if (split[type] || (type === 'js' && opts.alwaysWriteScript)) {
         stream.push(splitFile(file, splitfile[type], split[type]));
       }
     });

--- a/test.js
+++ b/test.js
@@ -143,4 +143,29 @@ describe('should do for csp', function () {
 
 		stream.end();
 	});
+
+	it('options test: alwaysWriteScript', function (cb) {
+		var stream = crisper({
+			alwaysWriteScript: Boolean
+		});
+
+		stream.on('data', function (file) {
+			var contents = file.contents.toString();
+
+			if (/.js$/.test(file.path)) {
+				assert(contents === '');
+			}
+		});
+
+		stream.on('end', cb);
+
+		stream.write(new gutil.File({
+			cwd: __dirname,
+			base: path.join(__dirname, 'tmp'),
+			path: path.join('tmp', 'index.html'),
+			contents: fs.readFileSync(path.join('tmp', 'index.html'))
+		}));
+
+		stream.end();
+	});
 });


### PR DESCRIPTION
The `alwaysWriteScript` option is documented to always produce
a script file, which is quite helpful when references to it exist
in other files. gulp-crisper however ignored empty keys in the
crisper output, so that the script was never written, regardless of
the option.
