### PR TITLE
Remove dependancy to gulp-util (deprecated)

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,12 +1,13 @@
 'use strict';
 var path = require('path');
-var gutil = require('gulp-util');
+var Vynil = require('vinyl');
 var through = require('through2');
 var crisper = require('crisper');
 var oassign = require('object-assign');
+var PluginError = require('plugin-error');
 
 function splitFile(file, filename, contents) {
-	return new gutil.File({
+	return new Vynil({
 		cwd: file.cwd,
 		base: file.base,
 		path: path.join(path.dirname(file.path), filename),
@@ -30,7 +31,7 @@ module.exports = function (opts) {
 		}
 
 		if (file.isStream()) {
-			cb(new gutil.PluginError('gulp-crisper', 'Streaming not supported'));
+			cb(new PluginError('gulp-crisper', 'Streaming not supported'));
 			return;
 		}
 

--- a/package.json
+++ b/package.json
@@ -29,16 +29,18 @@
   ],
   "dependencies": {
     "crisper": "^2.0.0",
-    "gulp-util": "^3.0.7",
     "object-assign": "^4.0.1",
-    "through2": "^2.0.0"
+    "plugin-error": "^1.0.1",
+    "through2": "^2.0.0",
+    "vinyl": "^2.2.1"
   },
   "devDependencies": {
     "ava": "^0.11.0",
-    "gulp-util": "^3.0.6",
     "gulp-vulcanize": "^6.0.1",
     "mkdirp": "^0.5.1",
+    "plugin-error": "^1.0.1",
     "rimraf": "^2.4.3",
+    "vinyl": "^2.2.1",
     "xo": "^0.12.1"
   }
 }

--- a/test.js
+++ b/test.js
@@ -3,7 +3,7 @@
 import test from 'ava';
 import fs from 'fs';
 import path from 'path';
-import gutil from 'gulp-util';
+import Vinyl from 'vinyl';
 import mkdirp from 'mkdirp';
 import rimraf from 'rimraf';
 import vulcanize from 'gulp-vulcanize';
@@ -28,7 +28,7 @@ test.beforeEach.cb(t => {
 
 	stream.on('end', t.end);
 
-	stream.write(new gutil.File({
+	stream.write(new Vinyl({
 		cwd: __dirname,
 		base: path.join(__dirname, 'tmp'),
 		path: path.join('tmp', 'index.html'),
@@ -59,7 +59,7 @@ test.cb('simple-usage', t => {
 
 	stream.on('end', t.end);
 
-	stream.write(new gutil.File({
+	stream.write(new Vinyl({
 		cwd: __dirname,
 		base: path.join(__dirname, 'tmp'),
 		path: path.join('tmp', 'vulcanize.html'),
@@ -84,7 +84,7 @@ test.cb('options test: scriptInHead', t => {
 
 	stream.on('end', t.end);
 
-	stream.write(new gutil.File({
+	stream.write(new Vinyl({
 		cwd: __dirname,
 		base: path.join(__dirname, 'tmp'),
 		path: path.join('tmp', 'vulcanize.html'),
@@ -109,7 +109,7 @@ test.cb('options test: onlySplit', t => {
 
 	stream.on('end', t.end);
 
-	stream.write(new gutil.File({
+	stream.write(new Vinyl({
 		cwd: __dirname,
 		base: path.join(__dirname, 'tmp'),
 		path: path.join('tmp', 'vulcanize.html'),
@@ -134,7 +134,7 @@ test.cb('options test: jsFileName', t => {
 
 	stream.on('end', t.end);
 
-	stream.write(new gutil.File({
+	stream.write(new Vinyl({
 		cwd: __dirname,
 		base: path.join(__dirname, 'tmp'),
 		path: path.join('tmp', 'vulcanize.html'),


### PR DESCRIPTION
Remove dependancy which is deprecated and carrying outdated version of lodash.
Move to Vinyl & PluginError to replace features provided by `gulp-util`.